### PR TITLE
Added missing semicolons

### DIFF
--- a/static/css/diffview.css
+++ b/static/css/diffview.css
@@ -30,11 +30,11 @@ or implied, of Chas Emerick.
 table.diff {
 	border-collapse:collapse;
 	border:1px solid darkgray;
-	white-space:pre-wrap
-        height:400px;
+	white-space:pre-wrap;
+	height:400px;
 }
 table.diff tbody { 
-	font-family:Courier, monospace
+	font-family:Courier, monospace;
 }
 table.diff tbody th {
 /*	font-family:verdana,arial,'Bitstream Vera Sans',helvetica,sans-serif;*/
@@ -45,7 +45,7 @@ table.diff tbody th {
 	color:#886;
 	padding:.3em .5em .1em 2em;
 	text-align:right;
-	vertical-align:top
+	vertical-align:top;
 }
 table.diff thead {
 	border-bottom:1px solid #BBC;
@@ -53,7 +53,7 @@ table.diff thead {
 /*	font-family:Verdana*/
 }
 table.diff thead th.texttitle {
-	text-align:left
+	text-align:left;
 }
 table.diff tbody td {
 	padding:0px .4em;
@@ -64,7 +64,7 @@ table.diff .empty {
 	background-color:#DDD;
 }
 table.diff .replace {
-	background-color:#FD8
+	background-color:#FD8;
 }
 table.diff .delete {
 	background-color:#E99;
@@ -75,12 +75,12 @@ table.diff .skip {
 	border-right:1px solid #BBC;
 }
 table.diff .insert {
-	background-color:#9E9
+	background-color:#9E9;
 }
 table.diff th.author {
 	text-align:right;
 	border-top:1px solid #BBC;
-	background:#EFEFEF
+	background:#EFEFEF;
 }
 tbody {
   overflow:scroll;


### PR DESCRIPTION
The CSS file was missing some semicolons, which caused warnings and possibly caused some styles to be ignored.