### PR TITLE
refactor: adopt template helper for eejsBlock_mySettings_dropdowns

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const eejs = require('ep_etherpad-lite/node/eejs');
+const {template} = require('ep_plugin_helpers');
 const settings = require('ep_etherpad-lite/node/utils/Settings');
 
 exports.eejsBlock_scripts = (hookName, args, cb) => {
@@ -23,10 +23,8 @@ exports.eejsBlock_timesliderScripts = (hookName, args, cb) => {
   cb();
 };
 
-exports.eejsBlock_mySettings_dropdowns = (hookName, args, cb) => {
-  args.content += eejs.require('ep_themes/templates/themesMenu.ejs');
-  cb();
-};
+exports.eejsBlock_mySettings_dropdowns =
+    template('ep_themes/templates/themesMenu.ejs');
 
 exports.clientVars = (hook, context, callback) => {
   let defaultTheme;

--- a/package.json
+++ b/package.json
@@ -33,5 +33,8 @@
   "scripts": {
     "lint": "eslint .",
     "lint:fix": "eslint --fix ."
+  },
+  "dependencies": {
+    "ep_plugin_helpers": "^0.5.0"
   }
 }


### PR DESCRIPTION
## Summary

Adopts the `template()` helper from `ep_plugin_helpers` for the `eejsBlock_mySettings_dropdowns` hook. Replaces the hand-rolled `(hookName, args, cb) => { args.content += eejs.require(path); cb(); }` boilerplate with one line. Same runtime behavior — eejs renders the same template into the same section.

Part of Phase 4 of the modernization campaign (helpers adoption). Pilot: ether/ep_align#182.

## Out of scope

- `eejsBlock_scripts` / `eejsBlock_timesliderScripts` — those PREPEND raw `<script>` tags rather than rendering an eejs template, so they don't fit `template`/`rawHTML`'s append semantics. Could be candidates for a future `rawHTMLPrepend` extension to `ep_plugin_helpers`.
- `clientVars` / `settings` adoption — would change the client-side payload shape (`theme_default` → `ep_themes.default_theme`) and break the existing `themes.js` reader. Worth doing alongside a client-side update; deferred.